### PR TITLE
refactor: batch release metadata generation

### DIFF
--- a/.github/scripts/generate_release.py
+++ b/.github/scripts/generate_release.py
@@ -1,0 +1,545 @@
+#!/usr/bin/env python3
+"""Generate release metadata for Envoy and Istio."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+CONFIG: Dict[str, Dict[str, object]] = {
+    "envoyproxy/envoy": {
+        "product": "envoy",
+        "strip_v_dir": True,
+        "images": [
+            {
+                "id": "base-image",
+                "ref": "envoyproxy/envoy:{tag}",
+                "registry": "envoyproxy/envoy",
+            },
+            {
+                "id": "base-image.distroless",
+                "ref": "envoyproxy/envoy:distroless-{tag_with_v}",
+                "registry": "envoyproxy/envoy",
+            },
+        ],
+        "publish": {
+            "docker-images": {
+                "fips": ["cloudsmith://docker-images/fips"],
+                "non-fips": [
+                    "cloudsmith://docker-images/addon",
+                    "cloudsmith://docker-images/non-fips",
+                ],
+            },
+            "linux-distribution-packages": {
+                "fips": ["cloudsmith://linux-distribution-packages/fips"],
+                "non-fips": ["cloudsmith://linux-distribution-packages/non-fips"],
+            },
+        },
+        "release_notes": "https://www.envoyproxy.io/docs/envoy/v{tag_no_v}/version_history/v{major_minor}/v{tag_no_v}",
+    },
+    "istio/istio": {
+        "product": "istio",
+        "strip_v_dir": False,
+        "images": [
+            {
+                "id": "base-image",
+                "ref": "gcr.io/istio-release/pilot:{tag_no_v}",
+                "registry": "gcr.io/istio-release/pilot",
+            },
+            {
+                "id": "base-image.distroless",
+                "ref": "gcr.io/istio-release/pilot:{tag_no_v}-distroless",
+                "registry": "gcr.io/istio-release/pilot",
+            },
+        ],
+        "publish": {
+            "docker-images": {
+                "fips": ["cloudsmith://docker-images/fips"],
+                "non-fips": [
+                    "cloudsmith://docker-images/addon",
+                    "cloudsmith://docker-images/non-fips",
+                ],
+            },
+            "linux-distribution-packages": {
+                "fips": ["cloudsmith://linux-distribution-packages/fips"],
+                "non-fips": ["cloudsmith://linux-distribution-packages/non-fips"],
+            },
+        },
+        "release_notes": "https://github.com/istio/istio/releases/tag/{tag}",
+    },
+}
+
+
+def log(msg: str) -> None:
+    print(msg, flush=True)
+def gh_request(path: str, token: Optional[str]) -> Optional[Any]:
+    url = f"https://api.github.com{path}"
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "istio-releases-action",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = Request(url, headers=headers)
+    try:
+        with urlopen(req) as resp:
+            if resp.status == 204:
+                return None
+            data = resp.read()
+            if not data:
+                return None
+            return json.loads(data.decode())
+    except HTTPError as exc:
+        if exc.code == 404:
+            return None
+        raise
+
+
+def resolve_tag(owner: str, repo: str, candidates: Iterable[str], token: Optional[str]) -> Tuple[str, str]:
+    for candidate in candidates:
+        if not candidate:
+            continue
+        path = f"/repos/{owner}/{repo}/git/ref/tags/{candidate}"
+        ref = gh_request(path, token)
+        if not ref:
+            continue
+        obj = ref.get("object", {})
+        sha = obj.get("sha")
+        typ = obj.get("type")
+        if not sha:
+            continue
+        if typ == "tag":
+            tag_obj = gh_request(f"/repos/{owner}/{repo}/git/tags/{sha}", token)
+            if not tag_obj:
+                raise RuntimeError(f"Unable to resolve annotated tag for {candidate}")
+            sha = (tag_obj.get("object") or {}).get("sha")
+            if not sha:
+                raise RuntimeError(f"Annotated tag missing object SHA for {candidate}")
+        return candidate, sha
+    raise SystemExit("Unable to resolve provided tag against GitHub API")
+
+
+def list_repo_tags(owner: str, repo: str, token: Optional[str]) -> List[Tuple[str, str]]:
+    tags: List[Tuple[str, str]] = []
+    page = 1
+    while True:
+        path = f"/repos/{owner}/{repo}/tags?per_page=100&page={page}"
+        response = gh_request(path, token)
+        if not response:
+            break
+        if not isinstance(response, list):
+            raise RuntimeError(f"Unexpected response for tag listing: {response!r}")
+        for item in response:
+            name = item.get("name") if isinstance(item, dict) else None
+            commit = item.get("commit") if isinstance(item, dict) else None
+            sha = commit.get("sha") if isinstance(commit, dict) else None
+            if name and sha:
+                tags.append((name, sha))
+        if len(response) < 100:
+            break
+        page += 1
+    return tags
+
+
+def semver_tuple(tag: str) -> Tuple[int, int, int]:
+    cleaned = tag.lstrip("v")
+    parts = cleaned.split(".")
+    nums = []
+    for part in parts[:3]:
+        match = re.match(r"(\d+)", part)
+        nums.append(int(match.group(1)) if match else 0)
+    while len(nums) < 3:
+        nums.append(0)
+    return tuple(nums[:3])
+
+
+def semver_ge(a: str, b: str) -> bool:
+    return semver_tuple(a) >= semver_tuple(b)
+
+
+def parse_start_from(raw: Optional[str]) -> Tuple[dict, Optional[str]]:
+    mapping: Dict[str, str] = {}
+    global_default: Optional[str] = None
+    if raw:
+        for item in raw.split(","):
+            item = item.strip()
+            if not item:
+                continue
+            if "@" in item:
+                repo, tag = item.split("@", 1)
+                mapping[repo.strip()] = tag.strip()
+            else:
+                global_default = item
+    return mapping, global_default
+
+
+def next_release_dir(base_dir: Path, version_part: str) -> Path:
+    candidate = base_dir / f"{version_part}+0"
+    return candidate
+
+
+def release_dir_exists(base_dir: Path, version_part: str) -> bool:
+    if not base_dir.exists():
+        return False
+    prefix = f"{version_part}+"
+    for path in base_dir.iterdir():
+        if path.is_dir() and path.name.startswith(prefix):
+            return True
+    return False
+
+
+def inspect_digest(image_ref: str) -> str:
+    cmd = [
+        "skopeo",
+        "inspect",
+        "--tls-verify=true",
+        "--format",
+        "{{.Digest}}",
+        f"docker://{image_ref}",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        stderr = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(f"Failed to inspect {image_ref}: {stderr}")
+    return result.stdout.strip()
+
+
+def dump_yaml(data: dict, destination: Path) -> None:
+    proc = subprocess.run(
+        ["yq", "-P", "."],
+        input=json.dumps(data),
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    destination.write_text(proc.stdout, encoding="utf-8")
+
+
+def diff_files(old: Path, new: Path) -> str:
+    if not old.exists() or not new.exists():
+        return ""
+    result = subprocess.run(
+        ["diff", "-ur", old.as_posix(), new.as_posix()],
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def find_previous_release(base_dir: Path, version_tuple: Tuple[int, int, int]) -> Optional[Path]:
+    if not base_dir.exists():
+        return None
+    candidates: list[Tuple[Tuple[int, int, int], int, Path]] = []
+    major_minor = version_tuple[:2]
+    for path in base_dir.iterdir():
+        if not path.is_dir():
+            continue
+        name = path.name
+        if "+" not in name:
+            continue
+        base, plus = name.rsplit("+", 1)
+        try:
+            iteration = int(plus)
+        except ValueError:
+            continue
+        parts = base.split(".")
+        try:
+            numbers = tuple(int(p) for p in parts)
+        except ValueError:
+            continue
+        if len(numbers) < 3:
+            numbers = numbers + (0,) * (3 - len(numbers))
+        if numbers[:2] != major_minor:
+            continue
+        if numbers >= version_tuple:
+            continue
+        candidates.append((numbers, iteration, path))
+    if not candidates:
+        return None
+    candidates.sort()
+    return candidates[-1][2]
+
+
+def write_output(name: str, value: str) -> None:
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        return
+    value = str(value)
+    with Path(output_path).open("a", encoding="utf-8") as fh:
+        if "\n" in value:
+            fh.write(f"{name}<<EOF\n{value}\nEOF\n")
+        else:
+            fh.write(f"{name}={value}\n")
+
+
+def slugify(value: str) -> str:
+    value = value.lower()
+    value = re.sub(r"[^a-z0-9]+", "-", value)
+    value = value.strip("-")
+    return value or "release"
+
+
+def generate_release(
+    repo_full: str,
+    resolved_tag: str,
+    sha: str,
+    cfg: Dict[str, object],
+) -> Optional[Dict[str, str]]:
+    product = cfg["product"]  # type: ignore[index]
+    strip_v_dir = bool(cfg.get("strip_v_dir"))
+    tag_no_v = resolved_tag[1:] if resolved_tag.startswith("v") else resolved_tag
+    tag_with_v = resolved_tag if resolved_tag.startswith("v") else f"v{resolved_tag}"
+    dir_version = tag_no_v if strip_v_dir else resolved_tag
+
+    releases_root = Path("releases") / str(product)
+    releases_root.mkdir(parents=True, exist_ok=True)
+
+    release_dir = next_release_dir(releases_root, dir_version)
+    if release_dir.exists():
+        log(f"Release directory {release_dir} already exists; skipping generation.")
+        return None
+
+    release_dir.mkdir(parents=True)
+
+    images_info: Dict[str, Dict[str, str]] = {}
+    for image in cfg["images"]:  # type: ignore[index]
+        image_id = image["id"]  # type: ignore[index]
+        ref_template = image["ref"]  # type: ignore[index]
+        registry = image["registry"]  # type: ignore[index]
+        ref = (
+            ref_template
+            .replace("{tag}", resolved_tag)
+            .replace("{tag_no_v}", tag_no_v)
+            .replace("{tag_with_v}", tag_with_v)
+        )
+        log(f"Inspecting {ref}")
+        digest = inspect_digest(ref)
+        images_info[image_id] = {
+            "registry": registry,
+            "digest": digest,
+        }
+
+    release_ref = f"{repo_full}@{sha}"
+    build_payload = {
+        "base-image": {
+            "registry": images_info["base-image"]["registry"],
+            "version": images_info["base-image"]["digest"],
+            "distroless": {
+                "registry": images_info["base-image.distroless"]["registry"],
+                "version": images_info["base-image.distroless"]["digest"],
+            },
+        },
+        "release": {"ref": release_ref},
+        "release-fips": {"ref": release_ref},
+    }
+    dump_yaml(build_payload, release_dir / "build.yaml")
+
+    major_minor = ".".join(tag_no_v.split(".")[:2]) or tag_no_v
+    publish_base = json.loads(json.dumps(cfg["publish"]))  # deep copy
+    publish_base.setdefault("release-notes", {})["announcement"] = (
+        cfg["release_notes"].format(  # type: ignore[index]
+            tag=resolved_tag,
+            tag_no_v=tag_no_v,
+            tag_with_v=tag_with_v,
+            major_minor=major_minor,
+        )
+    )
+    dump_yaml(publish_base, release_dir / "publish.yaml")
+
+    version_tuple = semver_tuple(resolved_tag)
+    previous_dir = find_previous_release(releases_root, version_tuple)
+
+    issue_lines = [f"Update to the latest {major_minor} minor.", ""]
+    if previous_dir:
+        prev_build = previous_dir / "build.yaml"
+        prev_publish = previous_dir / "publish.yaml"
+        build_diff = diff_files(prev_build, release_dir / "build.yaml")
+        publish_diff = diff_files(prev_publish, release_dir / "publish.yaml")
+        if build_diff:
+            issue_lines.append(build_diff)
+            issue_lines.append("")
+        if publish_diff:
+            issue_lines.append(publish_diff)
+    else:
+        issue_lines.append("No previous release available for diff.")
+    issue_text = "\n".join(issue_lines).rstrip() + "\n"
+    (release_dir / "issue.md").write_text(issue_text, encoding="utf-8")
+
+    log(f"Generated release metadata in {release_dir}")
+
+    return {
+        "product": str(product),
+        "dir_version": release_dir.name,
+        "release_dir": release_dir.as_posix(),
+        "release_tag": resolved_tag,
+    }
+
+
+def main() -> None:
+    token = os.environ.get("GITHUB_TOKEN", "").strip() or None
+    start_from = os.environ.get("START_FROM")
+    release_env = os.environ.get("RELEASE", "").strip()
+
+    if release_env:
+        if "@" not in release_env:
+            raise SystemExit("RELEASE input must be in the form owner/repo@tag")
+
+        repo_full, provided_tag = release_env.split("@", 1)
+        repo_full = repo_full.strip()
+        provided_tag = provided_tag.strip()
+        if repo_full not in CONFIG:
+            raise SystemExit(f"Unsupported repository: {repo_full}")
+
+        cfg = CONFIG[repo_full]
+        owner, repo = repo_full.split("/")
+
+        if provided_tag.startswith("v"):
+            candidates = [provided_tag, provided_tag[1:]]
+        else:
+            candidates = [provided_tag, f"v{provided_tag}"]
+        candidates = [c for i, c in enumerate(candidates) if c and c not in candidates[:i]]
+
+        resolved_tag, sha = resolve_tag(owner, repo, candidates, token)
+        log(f"Resolved {repo_full}@{resolved_tag} -> {sha}")
+
+        mapping, global_default = parse_start_from(start_from)
+        baseline = mapping.get(repo_full, global_default)
+        if baseline and not semver_ge(resolved_tag, baseline):
+            log(f"Tag {resolved_tag} is before baseline {baseline}; nothing to do.")
+            write_output("changes", "false")
+            return
+
+        entry = generate_release(repo_full, resolved_tag, sha, cfg)
+        if not entry:
+            write_output("changes", "false")
+            return
+
+        version_slug = entry["dir_version"].replace("+", "-plus-")
+        branch_slug = slugify(f"{entry['product']}-{version_slug}")
+        write_output("changes", "true")
+        write_output("product", entry["product"])
+        write_output("version_dir", entry["dir_version"])
+        write_output("release_tag", entry["release_tag"])
+        write_output("release_dir", entry["release_dir"])
+        write_output("paths", entry["release_dir"])
+        write_output("summary", f"Generated {entry['product']} release at {entry['release_dir']}")
+        write_output("pr_branch", f"release/{branch_slug}")
+        write_output(
+            "commit_message",
+            f"chore: add {entry['product']} {entry['dir_version']} release metadata",
+        )
+        write_output(
+            "pr_title",
+            f"Add {entry['product']} {entry['dir_version']} release metadata",
+        )
+        body = (
+            "Automated release metadata for `"
+            f"{entry['release_tag']}`.\n\nGenerated directories:\n- `"
+            f"{entry['release_dir']}`"
+        )
+        write_output("pr_body", body)
+        return
+
+    mapping, global_default = parse_start_from(start_from)
+    generated: List[Dict[str, str]] = []
+
+    for repo_full, cfg in CONFIG.items():
+        owner, repo = repo_full.split("/")
+        baseline = mapping.get(repo_full, global_default)
+        tags = list_repo_tags(owner, repo, token)
+        if not tags:
+            log(f"No tags found for {repo_full}")
+            continue
+
+        tags.sort(key=lambda item: semver_tuple(item[0]))
+
+        product = cfg["product"]  # type: ignore[index]
+        strip_v_dir = bool(cfg.get("strip_v_dir"))
+        releases_root = Path("releases") / str(product)
+
+        for tag_name, _sha in tags:
+            if not re.match(r"^v?\d+\.\d+\.\d+", tag_name):
+                continue
+            if baseline and not semver_ge(tag_name, baseline):
+                continue
+            if tag_name.startswith("v"):
+                candidates = [tag_name, tag_name[1:]]
+            else:
+                candidates = [tag_name, f"v{tag_name}"]
+            candidates = [c for i, c in enumerate(candidates) if c and c not in candidates[:i]]
+
+            resolved_tag, sha = resolve_tag(owner, repo, candidates, token)
+            log(f"Resolved {repo_full}@{resolved_tag} -> {sha}")
+            tag_no_v = resolved_tag[1:] if resolved_tag.startswith("v") else resolved_tag
+            dir_version = tag_no_v if strip_v_dir else resolved_tag
+            if release_dir_exists(releases_root, dir_version):
+                continue
+            entry = generate_release(repo_full, resolved_tag, sha, cfg)
+            if entry:
+                generated.append(entry)
+
+    if not generated:
+        write_output("changes", "false")
+        return
+
+    first = generated[0]
+    count = len(generated)
+    version_slug = first["dir_version"].replace("+", "-plus-")
+    if count == 1:
+        branch_slug = slugify(f"{first['product']}-{version_slug}")
+        commit_message = f"chore: add {first['product']} {first['dir_version']} release metadata"
+        pr_title = f"Add {first['product']} {first['dir_version']} release metadata"
+        body = (
+            "Automated release metadata for `"
+            f"{first['release_tag']}`.\n\nGenerated directories:\n- `"
+            f"{first['release_dir']}`"
+        )
+        summary = f"Generated {first['product']} release at {first['release_dir']}"
+    else:
+        branch_slug = slugify(
+            f"batch-{first['product']}-{version_slug}-and-{count - 1}-more"
+        )
+        commit_message = f"chore: add release metadata for {count} updates"
+        pr_title = f"Add release metadata for {count} updates"
+        lines = [
+            f"- **{entry['product']}** `{entry['release_tag']}` -> `{entry['release_dir']}`"
+            for entry in generated
+        ]
+        body = (
+            "Automated release metadata for the following updates:\n"
+            + "\n".join(lines)
+        )
+        summary_lines = [
+            f"- {entry['product']} {entry['dir_version']}" for entry in generated
+        ]
+        summary = f"Generated {count} release updates:\n" + "\n".join(summary_lines)
+
+    paths = "\n".join(entry["release_dir"] for entry in generated)
+
+    write_output("changes", "true")
+    write_output("product", first["product"])
+    write_output("version_dir", first["dir_version"])
+    write_output("release_tag", first["release_tag"])
+    write_output("release_dir", first["release_dir"])
+    write_output("paths", paths)
+    write_output("summary", summary)
+    write_output("pr_branch", f"release/{branch_slug}")
+    write_output("commit_message", commit_message)
+    write_output("pr_title", pr_title)
+    write_output("pr_body", body)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit as exc:
+        if exc.code not in (0, None):
+            log(str(exc))
+        raise

--- a/.github/workflows/capture-envoy-istio.yaml
+++ b/.github/workflows/capture-envoy-istio.yaml
@@ -1,140 +1,32 @@
 name: Capture Envoy & Istio Releases
 
-# Capture Envoy & Istio Releases (obviously)
-
-# • Permissions: `contents: write` (to commit outputs).
-# • Concurrency: group `capture-releases`, do not cancel in-progress.
-# • Tools auto-installed: jq, curl, skopeo, yq (v4.x).
-# • Secrets: `GITHUB_TOKEN` (Actions-provided; unauth calls allowed but risk rate limits).
-
-# • Config (required): `CONFIG_JSON` env with `targets[]`:
-
-# * Fields per target: `repo`, `output_dir` (supports `{tag}`), `strip_v_prefix` (bool), `include_prereleases` (bool), `use_tags_if_no_releases` (bool), optional `images[]` (id, ref with `{tag}`/`{tag_no_v}`), optional `extra_refs[]` (key, resolve_for).
-# * Placeholders: `{tag}`, `{tag_no_v}`.
-
-# • Optional env:
-
-# * `START_FROM`: semver baseline; formats: global `vX.Y.Z` and/or per repo `owner/repo@vX.Y.Z` (comma-sep).
-# * `RUNTIME_IGNORE`: comma-sep `owner/repo@tag` to skip.
-# * `ACT`: set `true` to skip committing (local testing).
-
-# • Tag selection: only semver `^v?[0-9]+\.[0-9]+\.[0-9]+$`; filter prereleases if `include_prereleases=false`; fallback to `/tags` when no Releases and `use_tags_if_no_releases=true`; apply `START_FROM`, then `RUNTIME_IGNORE`; skip already processed tags.
-
-# • State (idempotency):
-
-# * `state/releases-processed.json` — per repo list of processed tags.
-# * `state/capture-failed.json` — array of failures with details/timestamps.
-
-# • Main job (`capture`) flow:
-
-# 1. List tags/releases via GitHub API (paged).
-# 2. For each unseen tag: resolve `extra_refs` to SHAs; inspect image digests via skopeo (best-effort).
-# 3. Write `releases/<product>/<tag>/release.yaml`.
-# 4. Update state; collect CREATED/FAILED arrays as step outputs.
-# 5. Commit changes if any (unless `ACT=true`).
-
-# • Generated file (`release.yaml`) shape:
-
-# * `base-image.registry|version` (digest), nested `.distroless.*`; `release.ref`, `release-fips.ref` as `owner/repo@<sha>` or null.
-
-# • Job outputs (for downstream use):
-
-# * `created` (JSON string array of file paths).
-# * `failed` (JSON array with `repo`, `tag`, `sha_errors`, `digest_errors`, `when`).
-
-# • Fan-out job (`act_on_captured`): runs once per file in `created` (matrix `file`); placeholder step to build/notify/PR.
-
-# • Commit scope: `releases/**`, `state/releases-processed.json`, `state/capture-failed.json`; message “chore: capture Envoy/Istio releases (best-effort)”.
-
-# • Common ops:
-
-# * Start from specific versions: set `START_FROM`.
-# * Ignore noisy tags: set `RUNTIME_IGNORE`.
-# * Local dry-run without commits: set `ACT=true`.
-# * Extend coverage: append targets to `CONFIG_JSON.targets`.
-
-###############
-
 on:
-  push:
-    branches:
-      - envoy-istio-metadata
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Target branch'
+        description: 'Target branch to base the pull request on'
         required: true
-        default: 'envoy-istio-metadata'
-        type: environment
+        default: 'main'
+        type: string
       start_from:
-        description: 'Envoy/Istio first release to process'
+        description: 'Optional START_FROM baseline (e.g. v1.34.0 or owner/repo@v1.34.0)'
         required: false
-        type: environment
-
-
+        type: string
 
 permissions:
   contents: write
 
-concurrency:
-  group: capture-releases
-  cancel-in-progress: false
-
 jobs:
   capture:
     runs-on: ubuntu-latest
-    outputs:
-      created: ${{ steps.finish.outputs.CREATED_JSON }}   # JSON array of created file paths
-      failed:  ${{ steps.finish.outputs.FAILED_JSON }}    # JSON array of failures
-    env:
-      # Hard-coded targets
-      CONFIG_JSON: |
-        {
-          "targets": [
-            {
-              "repo": "envoyproxy/envoy",
-              "output_dir": "releases/envoy/{tag}",
-              "strip_v_prefix": true,
-              "include_prereleases": false,
-              "use_tags_if_no_releases": true,
-              "ignore": { "tags": [], "regexes": [] },
-              "images": [
-                { "id": "base-image",            "ref": "envoyproxy/envoy:{tag}" },
-                { "id": "base-image.distroless", "ref": "envoyproxy/envoy:distroless-{tag}" }
-              ],
-              "extra_refs": [
-                { "key": "release",      "resolve_for": "{tag}" },
-                { "key": "release-fips", "resolve_for": "{tag}" }
-              ]
-            },
-            {
-              "repo": "istio/istio",
-              "output_dir": "releases/istio/{tag}",
-              "strip_v_prefix": false,
-              "include_prereleases": false,
-              "use_tags_if_no_releases": true,
-              "ignore": { "tags": [], "regexes": [] },
-              "images": [
-                { "id": "base-image",            "ref": "gcr.io/istio-release/pilot:{tag_no_v}" },
-                { "id": "base-image.distroless", "ref": "gcr.io/istio-release/pilot:{tag_no_v}-distroless" }
-              ],
-              "extra_refs": [
-                { "key": "release",      "resolve_for": "{tag}" },
-                { "key": "release-fips", "resolve_for": "{tag}" }
-              ]
-            }
-          ]
-        }
-      # Optional: skip specific tags without editing the JSON above (comma-separated)
-      RUNTIME_IGNORE: ""   # e.g. "envoyproxy/envoy@v1.0.0,istio/istio@1.27.0"
-
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out target branch
+        uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.branch }}
           fetch-depth: 0
 
-      - name: Install deps
-        shell: bash
+      - name: Install dependencies
         run: |
           sudo apt-get update -y
           sudo apt-get install -y jq curl skopeo
@@ -142,341 +34,33 @@ jobs:
             https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
           sudo chmod +x /usr/local/bin/yq
 
-      - name: Ensure state
-        shell: bash
-        run: |
-          mkdir -p state
-          test -f state/releases-processed.json || echo '{}' > state/releases-processed.json
-          test -f state/capture-failed.json     || echo '[]' > state/capture-failed.json
-
-      - name: Capture unseen releases (best-effort)
-        id: cap
-        shell: bash
+      - name: Generate release metadata
+        id: generate
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           START_FROM: ${{ inputs.start_from }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -Eeuo pipefail
+          python3 .github/scripts/generate_release.py
 
-          CONFIG='${{ env.CONFIG_JSON }}'
-          STATE=state/releases-processed.json
-          CREATED_JSON='[]'
-          FAILED_JSON='[]'
+      - name: Show summary
+        if: steps.generate.outputs.changes == 'true'
+        run: |
+          echo "${{ steps.generate.outputs.summary }}"
 
-          # put near the top of the step, after set -Eeuo pipefail
-          jqp() {  # usage: jqp "$json_var" 'jq filter'
-            printf '%s' "$1" | jq -r "$2"
-          }
-
-          # Parse START_FROM into a map and an optional global default
-          declare -A START_MAP=()
-          START_GLOBAL=""
-          if [[ -n "${START_FROM:-}" ]]; then
-            IFS=',' read -ra _sf_items <<< "$START_FROM"
-            for it in "${_sf_items[@]}"; do
-              it="${it//[[:space:]]/}"
-              [[ -z "$it" ]] && continue
-              if [[ "$it" == *@* ]]; then
-                # repo-specific: owner/repo@tag
-                START_MAP["${it%@*}"]="${it#*@}"
-              else
-                # global
-                START_GLOBAL="$it"
-              fi
-            done
-          fi
-
-          # semver compare: returns 0 if verA >= verB, 1 otherwise
-          semver_ge() {
-            local A="${1#v}" B="${2#v}"
-            local a1 a2 a3 b1 b2 b3
-            IFS='.' read -r a1 a2 a3 <<<"$A"
-            IFS='.' read -r b1 b2 b3 <<<"$B"
-            a1=${a1:-0}; a2=${a2:-0}; a3=${a3:-0}
-            b1=${b1:-0}; b2=${b2:-0}; b3=${b3:-0}
-            # numeric compare
-            if   (( a1 > b1 )); then return 0
-            elif (( a1 < b1 )); then return 1
-            fi
-            if   (( a2 > b2 )); then return 0
-            elif (( a2 < b2 )); then return 1
-            fi
-            if   (( a3 >= b3 )); then return 0
-            else return 1
-            fi
-          }
-
-          # decide if a tag is on/after the baseline for a repo
-          meets_start_baseline() {
-            local repo_full="$1" tag="$2"
-            local baseline="${START_MAP[$repo_full]:-$START_GLOBAL}"
-            [[ -z "$baseline" ]] && return 0           # no baseline => allow
-            semver_ge "$tag" "$baseline"
-          }
-
-
-          # token-aware curl (no 401 when testing without token)
-          safe_curl() {
-            if [[ -n "${GITHUB_TOKEN:-}" ]]; then
-              curl -fsSL -H "Authorization: Bearer ${GITHUB_TOKEN}" -H "Accept: application/vnd.github+json" "$@"
-            else
-              curl -fsSL -H "Accept: application/vnd.github+json" "$@"
-            fi
-          }
-
-          # runtime ignore set (env: RUNTIME_IGNORE="owner/repo@tag,owner/repo@tag2")
-          declare -A IGNORE_RT=()
-          if [[ -n "${RUNTIME_IGNORE:-}" ]]; then
-            IFS=',' read -ra _items <<< "$RUNTIME_IGNORE"
-            for it in "${_items[@]}"; do
-              it="${it//[[:space:]]/}"
-              [[ -n "$it" ]] && IGNORE_RT["$it"]=1
-            done
-          fi
-
-          jq_get() { printf '%s' "$1" | jq -r "$2 // empty"; }
-
-          list_tags() {
-            local owner="$1" repo="$2" include_pr="$3" use_fallback="$4"
-            local all="[]"; local page=1
-            while :; do
-              local r; r=$(safe_curl "https://api.github.com/repos/$owner/$repo/releases?per_page=100&page=$page" || echo '[]')
-              all=$( { printf '%s' "$all"; printf '%s' "$r"; } | jq -c -s 'add' )
-              if [ "$(printf '%s' "$r" | jq 'length')" -lt 100 ]; then break; fi
-              ((page++))
-            done
-            local out="[]"
-            if [ "$(printf '%s' "$all" | jq 'length')" -gt 0 ]; then
-              if [[ "$include_pr" == "true" ]]; then
-                out=$(printf '%s' "$all"  | jq -c '[ .[] | select(.draft==false) ] | sort_by(.created_at) | map(.tag_name)')
-              else
-                out=$(printf '%s' "$all" | jq -c '[ .[] | select(.draft==false and .prerelease==false) ] | sort_by(.created_at) | map(.tag_name)')
-              fi
-            elif [[ "$use_fallback" == "true" ]]; then
-              local tags="[]"; page=1
-              while :; do
-                local t; t=$(safe_curl "https://api.github.com/repos/$owner/$repo/tags?per_page=100&page=$page" || echo '[]')
-                tags=$( { printf '%s' "$tags"; printf '%s' "$t"; } | jq -c -s 'add' )
-                if [ "$(printf '%s' "$t" | jq 'length')" -lt 100 ]; then break; fi
-                ((page++))
-              done
-              out=$(printf '%s' "$tags" | jq -c 'reverse | map(.name)')
-            fi
-            echo "$out"
-          }
-
-          # Keep only sensible tags (semver); drop "untagged-..." etc.
-          is_valid_tag() {
-            local tag="$1"
-            [[ "$tag" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]
-          }
-
-          resolve_ref() { # prints SHA or empty
-            local owner="$1" repo="$2" ref="$3"
-            local r type sha
-            r=$(safe_curl "https://api.github.com/repos/$owner/$repo/git/ref/tags/${ref}" 2>/dev/null || true)
-            type=$(jq -r '.object.type // empty' <<<"$r")
-            sha=$(jq -r '.object.sha  // empty' <<<"$r")
-            if [[ -n "$type" ]]; then
-              if [[ "$type" == "tag" ]]; then
-                local t; t=$(safe_curl "https://api.github.com/repos/$owner/$repo/git/tags/${sha}" 2>/dev/null || true)
-                echo "$(jq -r '.object.sha // empty' <<<"$t")"; return 0
-              else
-                echo "$sha"; return 0
-              fi
-            fi
-            r=$(safe_curl "https://api.github.com/repos/$owner/$repo/git/ref/heads/${ref}" 2>/dev/null || true)
-            sha=$(jq -r '.object.sha // empty' <<<"$r")
-            [[ -n "$sha" ]] && { echo "$sha"; return 0; }
-            echo ""
-          }
-
-          process_one() {
-            local owner="$1" name="$2" tag="$3" target_json="$4"
-
-            local strip_v; strip_v=$(jq_get "$target_json" '.strip_v_prefix'); [[ -z "$strip_v" ]] && strip_v="false"
-            local tag_no_v="$tag"; if [[ "$strip_v" == "true" && "$tag_no_v" =~ ^v ]]; then tag_no_v="${tag_no_v#v}"; fi
-
-            # resolve SHAs
-            local extra='{}'; local sha_errors="[]"
-            local ecnt; ecnt=$(jq '(.extra_refs // []) | length' <<<"$target_json")
-            for (( i=0; i<ecnt; i++ )); do
-              local key ref_tpl ref sha
-              key=$(jq -r ".extra_refs[$i].key" <<<"$target_json")
-              ref_tpl=$(jq -r ".extra_refs[$i].resolve_for" <<<"$target_json")
-              ref="${ref_tpl//\{tag\}/$tag}"
-              sha=$(resolve_ref "$owner" "$name" "$ref" || true)
-              if [[ -n "$sha" ]]; then
-                extra=$(jq -c --arg k "$key" --arg s "$sha" '. + {($k): $s}' <<<"$extra")
-              else
-                sha_errors=$(jq -c --arg k "$key" --arg r "$ref" '. + [ {ref_key:$k, ref:$r} ]' <<<"$sha_errors")
-              fi
-            done
-
-            # resolve image digests (best-effort)
-            local dig='{}'; local dig_err='[]'
-            local icnt; icnt=$(jq '(.images // []) | length' <<<"$target_json")
-            for (( j=0; j<icnt; j++ )); do
-              local id tpl ref digv
-              id=$(jq -r ".images[$j].id" <<<"$target_json")
-              tpl=$(jq -r ".images[$j].ref" <<<"$target_json")
-              ref="${tpl//\{tag\}/$tag}"; ref="${ref//\{tag_no_v\}/$tag_no_v}"
-              if digv=$(skopeo inspect --tls-verify=true --format '{{.Digest}}' "docker://$ref" 2>/tmp/err.$$); then
-                dig=$(jq -c --arg id "$id" --arg ref "$ref" --arg d "$digv" '. + {($id): {ref:$ref, digest:$d}}' <<<"$dig")
-              else
-                dig_err=$(jq -c --arg id "$id" --arg ref "$ref" --arg msg "$(tail -1 /tmp/err.$$)" '. + [ {id:$id, ref:$ref, error:$msg} ]' <<<"$dig_err")
-              fi
-              rm -f /tmp/err.$$
-            done
-
-            # write YAML (null-safe; no jq // operator)
-            local out_dir_tpl out_dir out_file
-            out_dir_tpl=$(jq_get "$target_json" '.output_dir')
-            out_dir="${out_dir_tpl//\{tag\}/$tag}"
-            mkdir -p "$out_dir"
-            out_file="$out_dir/release.yaml"
-
-            local base_ref base_dig dist_ref dist_dig rel_sha fips_sha
-            base_ref=$(printf '%s' "$dig"   | jq -r '."base-image".ref // empty')
-            base_dig=$(printf '%s' "$dig"   | jq -r '."base-image".digest // empty')
-            dist_ref=$(printf '%s' "$dig"   | jq -r '."base-image.distroless".ref // empty')
-            dist_dig=$(printf '%s' "$dig"   | jq -r '."base-image.distroless".digest // empty')
-            rel_sha=$(printf '%s' "$extra"  | jq -r '."release" // empty')
-            fips_sha=$(printf '%s' "$extra" | jq -r '."release-fips" // empty')
-
-            jq -n \
-              --arg base_reg "$base_ref" \
-              --arg base_dig "$base_dig" \
-              --arg dist_reg "$dist_ref" \
-              --arg dist_dig "$dist_dig" \
-              --arg owner "$owner" \
-              --arg name "$name" \
-              --arg rel_sha "$rel_sha" \
-              --arg fips_sha "$fips_sha" \
-              '
-              def nn(s): if s == "" then null else s end;
-              def refify(s): if s == "" then null else ($owner + "/" + $name + "@" + s) end;
-
-              {
-                "base-image": {
-                  "registry": nn($base_reg),
-                  "version":  nn($base_dig),
-                  "distroless": {
-                    "registry": nn($dist_reg),
-                    "version":  nn($dist_dig)
-                  }
-                },
-                "release":      { "ref": refify($rel_sha) },
-                "release-fips": { "ref": refify($fips_sha) }
-              }
-              ' \
-            | yq -P > "$out_file"
-
-            echo "$out_file"
-            echo "$sha_errors" > state/.sha_errors.json
-            echo "$dig_err"    > state/.dig_errors.json
-          }
-
-          CREATED='[]'
-          FAILED='[]'
-
-          # Stream targets (no argv blow-ups)
-          while IFS= read -r t; do
-            repo=$(jq_get "$t" '.repo')
-            owner="${repo%%/*}"
-            name="${repo##*/}"
-
-            include=$(jq_get "$t" '.include_prereleases'); [[ -z "$include" ]] && include="false"
-            fallback=$(jq_get "$t" '.use_tags_if_no_releases'); [[ -z "$fallback" ]] && fallback="true"
-
-            tags_json=$(list_tags "$owner" "$name" "$include" "$fallback")
-            seen=$(jq -c --arg k "$repo" '.[$k].processed // []' "$STATE")
-
-            # Stream tags (avoid argv explosion). Filter to semver.
-            while IFS= read -r tag; do
-              # filter noisy tags
-              if ! is_valid_tag "$tag"; then
-                echo "== skip (non-semver) $repo $tag"
-                continue
-              fi
-
-              # baseline filter
-              if ! meets_start_baseline "$repo" "$tag"; then
-                echo "== skip (before baseline ${START_MAP[$repo]:-$START_GLOBAL}) $repo $tag"
-                continue
-              fi
-
-              # runtime ignore?
-              if [[ -n "${IGNORE_RT["$repo@$tag"]+x}" ]]; then
-                echo "== skip (runtime ignore) $repo $tag"
-                continue
-              fi
-
-              # already processed?
-              if printf '%s' "$seen" | jq -e --arg tg "$tag" 'index($tg) != null' >/dev/null; then
-                continue
-              fi
-
-              echo "== process $repo $tag"
-              if file_path=$(process_one "$owner" "$name" "$tag" "$t"); then
-                CREATED=$(printf '%s' "$CREATED" | jq -c --arg f "$file_path" '. + [ $f ]')
-                # mark seen (only on success)
-                new_seen=$(printf '%s' "$seen" | jq -c --arg tg "$tag" '. + [ $tg ] | unique')
-                jq --arg k "$repo" --argjson arr "$new_seen" '.[$k].processed = $arr' "$STATE" > state/.tmp && mv state/.tmp "$STATE"
-              else
-                FAILED=$(printf '%s' "$FAILED" | jq -c --arg r "$repo" --arg tg "$tag" '. + [ {repo:$r, tag:$tg, error:"capture-failed"} ]')
-              fi
-
-              # append detailed errors, if any
-              if [[ -s state/.sha_errors.json || -s state/.dig_errors.json ]]; then
-                sha_e=$(cat state/.sha_errors.json 2>/dev/null || echo '[]')
-                dig_e=$(cat state/.dig_errors.json 2>/dev/null || echo '[]')
-                jq -n --arg r "$repo" --arg tg "$tag" --argjson se "$sha_e" --argjson de "$dig_e" \
-                  '{repo:$r, tag:$tg, sha_errors:$se, digest_errors:$de, when:(now|todate)}' \
-                | jq -s '.[0]' > state/.last_fail.json
-                jq -s '.[0] + [.[1]]' state/capture-failed.json state/.last_fail.json > state/.tmp && mv state/.tmp state/capture-failed.json
-                rm -f state/.sha_errors.json state/.dig_errors.json state/.last_fail.json || true
-              fi
-            done < <(jq -r '.[]' <<<"$tags_json")
-          done < <(jq -c '.targets[]' <<<"$CONFIG")
-
-          echo "CREATED<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$CREATED"     >> "$GITHUB_OUTPUT"
-          echo "EOF"          >> "$GITHUB_OUTPUT"
-
-          echo "FAILED<<EOF"  >> "$GITHUB_OUTPUT"
-          echo "$FAILED"      >> "$GITHUB_OUTPUT"
-          echo "EOF"          >> "$GITHUB_OUTPUT"
-  
-
-      - name: Commit outputs (if any)
-        if: ${{ (steps.cap.outputs.CREATED != '[]' || steps.cap.outputs.FAILED != '[]') && env.ACT != 'true' }}
-        uses: stefanzweifel/git-auto-commit-action@v5
+      - name: Create pull request
+        if: steps.generate.outputs.changes == 'true'
+        uses: peter-evans/create-pull-request@v6
         with:
-          commit_message: "chore: capture Envoy/Istio releases (best-effort)"
-          file_pattern: |
-            state/releases-processed.json
-            state/capture-failed.json
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ inputs.branch }}
+          branch: ${{ steps.generate.outputs.pr_branch }}
+          commit-message: ${{ steps.generate.outputs.commit_message }}
+          title: ${{ steps.generate.outputs.pr_title }}
+          body: ${{ steps.generate.outputs.pr_body }}
+          add-paths: ${{ steps.generate.outputs.paths }}
+          signoff: false
+          delete-branch: true
 
-      - name: Finish / expose outputs
-        id: finish
-        shell: bash
-        run: |
-          echo 'CREATED_JSON=${{ steps.cap.outputs.CREATED }}' >> "$GITHUB_OUTPUT"
-          echo 'FAILED_JSON=${{ steps.cap.outputs.FAILED }}'   >> "$GITHUB_OUTPUT"
-
-  act_on_captured:
-    needs: capture
-    if: ${{ needs.capture.outputs.created != '[]' }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        file: ${{ fromJSON(needs.capture.outputs.created) }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use generated YAML
-        run: |
-          echo "Processing ${{ matrix.file }}"
-          test -f "${{ matrix.file }}" && cat "${{ matrix.file }}" || echo "(file missing?)"
-          # TODO: build image / notify / open PR, whatever
+      - name: No changes detected
+        if: steps.generate.outputs.changes != 'true'
+        run: echo "No new release artifacts were generated."


### PR DESCRIPTION
## Summary
- update the release generator to resolve repository tag listings, skip existing release directories, and emit batched pull request metadata when multiple versions are created
- fix Envoy distroless inspection by using the v-prefixed tag reference when pulling image digests
- streamline the capture workflow by removing the required release input and wiring the new summary, body, and add-path outputs

## Testing
- python3 -m compileall .github/scripts/generate_release.py

------
https://chatgpt.com/codex/tasks/task_e_68e57e3c7b348323a07507f57642a9f7